### PR TITLE
feat: 주문 도메인 기능 구현

### DIFF
--- a/src/main/java/com/nbcamp/orderservice/domain/common/CustomPageableArgumentResolver.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/common/CustomPageableArgumentResolver.java
@@ -1,0 +1,38 @@
+package com.nbcamp.orderservice.domain.common;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumentResolver  {
+
+	@Override
+	public Pageable resolveArgument(
+		MethodParameter methodParameter,
+		ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+		Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+		pageable = validatePageSize(pageable);
+
+
+		return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+	}
+
+	private Pageable validatePageSize(Pageable pageable) {
+		int pageSize = pageable.getPageSize();
+		if (pageSize == 10 || pageSize == 30 || pageSize == 50) {
+			return pageable;
+		} else {
+			return PageRequest.of(pageable.getPageNumber(), 10, pageable.getSort());
+		}
+	}
+
+
+}
+

--- a/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
@@ -61,7 +61,8 @@ public class OrderController {
 		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
 		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
 		@RequestParam(value = "orderStatus", required = false) OrderStatus orderStatus,
-		@RequestParam(value = "sortOption", required = false, defaultValue = "CREATED_AT_ASC") SortOption sortOption
+		@RequestParam(value = "sortOption", required = false, defaultValue = "CREATED_AT_ASC") SortOption sortOption,
+		@AuthenticationPrincipal UserDetailsImpl UserDetailsImpl
 	) {
 		return CommonResponse.success(SuccessCode.SUCCESS,
 			orderService.getOrdersAdmin(
@@ -71,7 +72,8 @@ public class OrderController {
 				startDate,
 				endDate,
 				orderStatus,
-				sortOption
+				sortOption,
+				UserDetailsImpl.getUser()
 			));
 	}
 

--- a/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
@@ -1,14 +1,20 @@
 package com.nbcamp.orderservice.domain.order.api;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nbcamp.orderservice.domain.order.dto.OrderInfoDto;
 import com.nbcamp.orderservice.domain.order.dto.OrderRequest;
 import com.nbcamp.orderservice.domain.order.dto.OrderResponse;
 import com.nbcamp.orderservice.domain.order.service.OrderService;
@@ -26,7 +32,7 @@ public class OrderController {
 	private final OrderService orderService;
 
 	@PostMapping("/orders")
-	public ResponseEntity<CommonResponse<OrderResponse>> createOrder(
+	public ResponseEntity<CommonResponse<OrderInfoDto>> createOrder(
 		@RequestBody OrderRequest request,
 		@AuthenticationPrincipal UserDetailsImpl userDetails
 	) {

--- a/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
@@ -1,32 +1,29 @@
 package com.nbcamp.orderservice.domain.order.api;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.nbcamp.orderservice.domain.common.OrderStatus;
-import com.nbcamp.orderservice.domain.common.OrderType;
-import com.nbcamp.orderservice.domain.common.SortOption;
 import com.nbcamp.orderservice.domain.order.dto.OrderInfoResponse;
 import com.nbcamp.orderservice.domain.order.dto.OrderProductResponse;
 import com.nbcamp.orderservice.domain.order.dto.OrderRequest;
 import com.nbcamp.orderservice.domain.order.dto.OrderResponse;
+import com.nbcamp.orderservice.domain.order.dto.OrderSearchAdminRequest;
+import com.nbcamp.orderservice.domain.order.dto.OrderSearchCustomerRequest;
 import com.nbcamp.orderservice.domain.order.dto.OrderUpdateRequest;
 import com.nbcamp.orderservice.domain.order.service.OrderService;
 import com.nbcamp.orderservice.global.exception.code.SuccessCode;
@@ -45,7 +42,7 @@ public class OrderController {
 
 	@PostMapping("/orders")
 	public ResponseEntity<CommonResponse<OrderInfoResponse>> createOrder(
-		@RequestBody OrderRequest request,
+		@Valid @RequestBody OrderRequest request,
 		@AuthenticationPrincipal UserDetailsImpl userDetails
 	) {
 		return CommonResponse.success(SuccessCode.SUCCESS_INSERT,
@@ -57,22 +54,14 @@ public class OrderController {
 	public ResponseEntity<CommonResponse<Page<OrderResponse>>> getAllOrdersAdmin(
 		Pageable pageable,
 		@PathVariable UUID storeId,
-		@RequestParam(value = "orderType", required = false) OrderType orderType,
-		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
-		@RequestParam(value = "orderStatus", required = false) OrderStatus orderStatus,
-		@RequestParam(value = "sortOption", required = false, defaultValue = "CREATED_AT_ASC") SortOption sortOption,
+		@Valid @ModelAttribute OrderSearchAdminRequest orderSearchAdminRequest,
 		@AuthenticationPrincipal UserDetailsImpl UserDetailsImpl
 	) {
 		return CommonResponse.success(SuccessCode.SUCCESS,
 			orderService.getOrdersAdmin(
 				pageable,
 				storeId,
-				orderType,
-				startDate,
-				endDate,
-				orderStatus,
-				sortOption,
+				orderSearchAdminRequest,
 				UserDetailsImpl.getUser()
 			));
 	}
@@ -82,25 +71,13 @@ public class OrderController {
 	public ResponseEntity<CommonResponse<Page<OrderResponse>>> getAllOrdersCustomer(
 		Pageable pageable,
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
-		@RequestParam(required = false) String storeName,
-		@RequestParam(required = false) UUID categoryId,
-		@RequestParam(value = "orderType", required = false) OrderType orderType,
-		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
-		@RequestParam(value = "orderStatus", required = false) OrderStatus orderStatus,
-		@RequestParam(value = "sortOption", required = false, defaultValue = "CREATED_AT_ASC") SortOption sortOption
+		@Valid @ModelAttribute OrderSearchCustomerRequest orderSearchCustomerRequest
 	) {
 		return CommonResponse.success(SuccessCode.SUCCESS,
 			orderService.getOrdersCustomer(
 				pageable,
 				userDetails.getUser(),
-				storeName,
-				categoryId,
-				orderType,
-				startDate,
-				endDate,
-				orderStatus,
-				sortOption
+				orderSearchCustomerRequest
 			));
 	}
 

--- a/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
@@ -1,0 +1,38 @@
+package com.nbcamp.orderservice.domain.order.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nbcamp.orderservice.domain.order.dto.OrderRequest;
+import com.nbcamp.orderservice.domain.order.dto.OrderResponse;
+import com.nbcamp.orderservice.domain.order.service.OrderService;
+import com.nbcamp.orderservice.global.exception.code.SuccessCode;
+import com.nbcamp.orderservice.global.response.CommonResponse;
+import com.nbcamp.orderservice.global.security.UserDetailsImpl;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping(value = {"/api/v1"})
+@RequiredArgsConstructor
+public class OrderController {
+
+	private final OrderService orderService;
+
+	@PostMapping("/orders")
+	public ResponseEntity<CommonResponse<OrderResponse>> createOrder(
+		@RequestBody OrderRequest request,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		return CommonResponse.success(SuccessCode.SUCCESS_INSERT,
+			orderService.createOrder(request, userDetails.getUser()));
+	}
+
+
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
@@ -58,7 +58,6 @@ public class OrderController {
 		if (size != 10 && size != 30 && size != 50) {
 			size = 10; // 기본값으로 고정
 		}
-		;
 		Sort sortCriteria = Sort.by(
 			"desc".equalsIgnoreCase(direction) ? Sort.Direction.DESC : Sort.Direction.ASC, sort
 		);

--- a/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
@@ -1,6 +1,7 @@
 package com.nbcamp.orderservice.domain.order.api;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -24,6 +25,7 @@ import com.nbcamp.orderservice.domain.common.OrderType;
 import com.nbcamp.orderservice.domain.common.SortOption;
 import com.nbcamp.orderservice.domain.common.UserRole;
 import com.nbcamp.orderservice.domain.order.dto.OrderInfoResponse;
+import com.nbcamp.orderservice.domain.order.dto.OrderProductResponse;
 import com.nbcamp.orderservice.domain.order.dto.OrderRequest;
 import com.nbcamp.orderservice.domain.order.dto.OrderResponse;
 import com.nbcamp.orderservice.domain.order.service.OrderService;
@@ -102,9 +104,12 @@ public class OrderController {
 
 
 	@GetMapping("/orders/{orderId}")
-	public ResponseEntity<CommonResponse<OrderInfoResponse>> getOrderDetail(@PathVariable String orderId) {
-		OrderInfoResponse orderInfo = orderService.getOrderDetail(UUID.fromString(orderId));
-		return CommonResponse.success(SuccessCode.SUCCESS, orderInfo);
+	public ResponseEntity<CommonResponse<List<OrderProductResponse>>> getOrderDetail(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@PathVariable UUID orderId
+	) {
+		return CommonResponse.success(SuccessCode.SUCCESS,
+			orderService.getOrderDetail(orderId, userDetails.getUser()));
 	}
 
 	@PatchMapping("orders/{orderId}")

--- a/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
@@ -125,7 +125,7 @@ public class OrderController {
 	@DeleteMapping("/orders/{orderId}")
 	public ResponseEntity<CommonResponse<Void>> cancelOrder(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
-		@PathVariable String orderId) {
+		@PathVariable UUID orderId) {
 		orderService.cancelOrder(orderId, userDetails.getUser());
 		return CommonResponse.success(SuccessCode.SUCCESS_DELETE);
 	}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
@@ -34,5 +34,12 @@ public class OrderController {
 			orderService.createOrder(request, userDetails.getUser()));
 	}
 
+	@DeleteMapping("/orders/{orderId}")
+	public ResponseEntity<CommonResponse<Void>> cancelOrder(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@PathVariable String orderId) {
+		orderService.cancelOrder(orderId, userDetails.getUser());
+		return CommonResponse.success(SuccessCode.SUCCESS_DELETE);
+	}
 
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
@@ -1,5 +1,7 @@
 package com.nbcamp.orderservice.domain.order.api;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -16,7 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.nbcamp.orderservice.domain.order.dto.OrderInfoDto;
 import com.nbcamp.orderservice.domain.order.dto.OrderRequest;
-import com.nbcamp.orderservice.domain.order.dto.OrderResponse;
 import com.nbcamp.orderservice.domain.order.service.OrderService;
 import com.nbcamp.orderservice.global.exception.code.SuccessCode;
 import com.nbcamp.orderservice.global.response.CommonResponse;
@@ -40,6 +41,26 @@ public class OrderController {
 			orderService.createOrder(request, userDetails.getUser()));
 	}
 
+	@GetMapping("/orders")
+	public ResponseEntity<CommonResponse<Page<OrderInfoDto>>> getAllOrders(
+		@RequestParam(value = "query", required = false) String query,
+		@RequestParam(value = "sort", defaultValue = "createdAt") String sort, // 기본 정렬: 생성일
+		@RequestParam(value = "direction", defaultValue = "desc") String direction, // 기본 정렬 순서: 내림차순
+		@RequestParam(value = "size", defaultValue = "10") int size,
+		@RequestParam(value = "page", defaultValue = "0") int page,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		if (size != 10 && size != 30 && size != 50) {
+			size = 10; // 기본값으로 고정
+		}
+		;
+		Sort sortCriteria = Sort.by(
+			"desc".equalsIgnoreCase(direction) ? Sort.Direction.DESC : Sort.Direction.ASC, sort
+		);
+		return CommonResponse.success(SuccessCode.SUCCESS,
+			orderService.getOrders(PageRequest.of(page, size, sortCriteria), userDetails.getUser(), query));
+	}
+
 	@DeleteMapping("/orders/{orderId}")
 	public ResponseEntity<CommonResponse<Void>> cancelOrder(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -47,5 +68,6 @@ public class OrderController {
 		orderService.cancelOrder(orderId, userDetails.getUser());
 		return CommonResponse.success(SuccessCode.SUCCESS_DELETE);
 	}
+
 
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/api/OrderController.java
@@ -69,5 +69,10 @@ public class OrderController {
 		return CommonResponse.success(SuccessCode.SUCCESS_DELETE);
 	}
 
+	@GetMapping("/orders/{orderId}")
+	public ResponseEntity<CommonResponse<OrderInfoDto>> getOrderDetail(@PathVariable String orderId) {
+		OrderInfoDto orderInfo = orderService.getOrderDetail(UUID.fromString(orderId));
+		return CommonResponse.success(SuccessCode.SUCCESS, orderInfo);
+	}
 
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderInfoDto.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderInfoDto.java
@@ -1,0 +1,9 @@
+package com.nbcamp.orderservice.domain.order.dto;
+
+import java.util.List;
+
+public record OrderInfoDto(
+	OrderResponse orderResponse,
+	List<OrderProductResponse> orderProductResponse
+) {
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderInfoResponse.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderInfoResponse.java
@@ -2,7 +2,7 @@ package com.nbcamp.orderservice.domain.order.dto;
 
 import java.util.List;
 
-public record OrderInfoDto(
+public record OrderInfoResponse(
 	OrderResponse orderResponse,
 	List<OrderProductResponse> orderProductResponse
 ) {

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderProductResponse.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderProductResponse.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 public record OrderProductResponse(
 	UUID orderProductId,
-	UUID orderId,
 	UUID productId,
 	String productName,
 	int quantity,

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderProductResponse.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderProductResponse.java
@@ -1,0 +1,13 @@
+package com.nbcamp.orderservice.domain.order.dto;
+
+import java.util.UUID;
+
+public record OrderProductResponse(
+	UUID orderProductId,
+	UUID orderId,
+	UUID productId,
+	String productName,
+	int quantity,
+	int price
+) {
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderProductResponse.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderProductResponse.java
@@ -7,6 +7,6 @@ public record OrderProductResponse(
 	UUID productId,
 	String productName,
 	int quantity,
-	int price
+	int productTotalPrice
 ) {
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderProductResponse.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderProductResponse.java
@@ -2,6 +2,8 @@ package com.nbcamp.orderservice.domain.order.dto;
 
 import java.util.UUID;
 
+import com.nbcamp.orderservice.domain.order.entity.OrderProduct;
+
 public record OrderProductResponse(
 	UUID orderProductId,
 	UUID productId,
@@ -9,4 +11,13 @@ public record OrderProductResponse(
 	int quantity,
 	int productTotalPrice
 ) {
+	public OrderProductResponse(OrderProduct orderProduct){
+		this(
+			orderProduct.getId(),
+			orderProduct.getProduct().getId(),
+			orderProduct.getProduct().getName(),
+			orderProduct.getQuantity(),
+			orderProduct.getTotalPrice()
+			);
+	}
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderRequest.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderRequest.java
@@ -1,21 +1,36 @@
 package com.nbcamp.orderservice.domain.order.dto;
 
-import com.nbcamp.orderservice.domain.common.OrderType;
-
 import java.util.List;
 import java.util.UUID;
 
+import com.nbcamp.orderservice.domain.common.OrderType;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
 public record OrderRequest(
+	@NotNull
 	UUID storeId,
+	@NotNull
 	OrderType type,
+	@NotNull
 	String address,
+	@Nullable
 	String request,
+	@Min(0)
 	int price,
+	@NotNull
+	@Valid
 	List<OrderProduct> products
 ) {
 	public record OrderProduct(
+		@NotNull
 		UUID productId,
+		@Min(0)
 		int quantity,
+		@Min(0)
 		int price) {
 	}
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderRequest.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderRequest.java
@@ -9,28 +9,31 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record OrderRequest(
-	@NotNull
+	@NotNull(message = "매장 정보입력은 필수 입니다")
 	UUID storeId,
-	@NotNull
+	@NotNull(message = "매장 주문 방식 입력은 필수입니다")
 	OrderType type,
-	@NotNull
+	@Size(max = 200, message = "주소는 200자 이내로 작성해 주세요.")
+	@NotNull(message = "")
 	String address,
 	@Nullable
+	@Size(max = 100, message = "요청사항은 100자 이내로 작성해 주세요")
 	String request,
-	@Min(0)
+	@Min(value = 0, message = "음수는 불가능 합니다.")
 	int price,
-	@NotNull
+	@NotNull(message = "주문 상품 정보는 필수입니다")
 	@Valid
 	List<OrderProduct> products
 ) {
 	public record OrderProduct(
-		@NotNull
+		@NotNull(message = "상품 정보는 필수입니다.")
 		UUID productId,
-		@Min(0)
+		@Min(value = 0, message = "음수는 불가능 합니다.")
 		int quantity,
-		@Min(0)
+		@Min(value = 0, message = "음수는 불가능 합니다.")
 		int price) {
 	}
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderRequest.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderRequest.java
@@ -1,0 +1,21 @@
+package com.nbcamp.orderservice.domain.order.dto;
+
+import com.nbcamp.orderservice.domain.common.OrderType;
+
+import java.util.List;
+import java.util.UUID;
+
+public record OrderRequest(
+	UUID storeId,
+	OrderType type,
+	String address,
+	String request,
+	int price,
+	List<OrderProduct> products
+) {
+	public record OrderProduct(
+		UUID productId,
+		int quantity,
+		int price) {
+	}
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderResponse.java
@@ -1,6 +1,5 @@
 package com.nbcamp.orderservice.domain.order.dto;
 
-import java.util.List;
 import java.util.UUID;
 
 import com.nbcamp.orderservice.domain.common.OrderStatus;
@@ -8,18 +7,12 @@ import com.nbcamp.orderservice.domain.common.OrderType;
 
 public record OrderResponse(
 	UUID orderId,
-	OrderStatus status,
 	UUID storeId,
+	UUID userId,
+	OrderStatus status,
 	OrderType type,
 	String address,
 	String request,
-	int price,
-	List<OrderProductResponse> products
+	int price
 ) {
-	public record OrderProductResponse(
-		UUID orderProductId,
-		UUID productId,
-		int quantity,
-		int price) {
-	}
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderResponse.java
@@ -1,0 +1,25 @@
+package com.nbcamp.orderservice.domain.order.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.nbcamp.orderservice.domain.common.OrderStatus;
+import com.nbcamp.orderservice.domain.common.OrderType;
+
+public record OrderResponse(
+	UUID orderId,
+	OrderStatus status,
+	UUID storeId,
+	OrderType type,
+	String address,
+	String request,
+	int price,
+	List<OrderProductResponse> products
+) {
+	public record OrderProductResponse(
+		UUID orderProductId,
+		UUID productId,
+		int quantity,
+		int price) {
+	}
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderResponse.java
@@ -11,8 +11,8 @@ public record OrderResponse(
 	UUID userId,
 	OrderStatus status,
 	OrderType type,
-	String address,
-	String request,
-	int price
+	String deliveryAddress,
+	String content,
+	int totalPrice
 ) {
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderResponse.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import com.nbcamp.orderservice.domain.common.OrderStatus;
 import com.nbcamp.orderservice.domain.common.OrderType;
+import com.nbcamp.orderservice.domain.order.entity.Order;
 
 public record OrderResponse(
 	UUID orderId,
@@ -15,4 +16,16 @@ public record OrderResponse(
 	String content,
 	int totalPrice
 ) {
+	public OrderResponse(Order order) {
+		this(
+			order.getId(),
+			order.getStore().getId(),
+			order.getUser().getId(),
+			order.getOrderStatus(),
+			order.getOrderType(),
+			order.getDeliveryAddress(),
+			order.getRequest(),
+			order.getTotalPrice()
+		);
+	}
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderSearchAdminRequest.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderSearchAdminRequest.java
@@ -1,0 +1,17 @@
+package com.nbcamp.orderservice.domain.order.dto;
+
+import java.time.LocalDate;
+
+import com.nbcamp.orderservice.domain.common.OrderStatus;
+import com.nbcamp.orderservice.domain.common.OrderType;
+import com.nbcamp.orderservice.domain.common.SortOption;
+
+public record OrderSearchAdminRequest(
+	OrderType orderType,
+	LocalDate startDate,
+	LocalDate endDate,
+	OrderStatus orderStatus,
+	SortOption sortOption
+
+) {
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderSearchCustomerRequest.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderSearchCustomerRequest.java
@@ -1,0 +1,22 @@
+package com.nbcamp.orderservice.domain.order.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import com.nbcamp.orderservice.domain.common.OrderStatus;
+import com.nbcamp.orderservice.domain.common.OrderType;
+import com.nbcamp.orderservice.domain.common.SortOption;
+
+import jakarta.validation.constraints.Size;
+
+public record OrderSearchCustomerRequest(
+	@Size(max = 50, message = "매장명은 50자 이내로 작성해 주세요")
+	String storeName,
+	UUID categoryId,
+	OrderType orderType,
+	LocalDate startDate,
+	LocalDate endDate,
+	OrderStatus orderStatus,
+	SortOption sortOption
+) {
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderUpdateRequest.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/dto/OrderUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.nbcamp.orderservice.domain.order.dto;
+
+import com.nbcamp.orderservice.domain.common.OrderStatus;
+
+import jakarta.annotation.Nullable;
+
+public record OrderUpdateRequest(
+	@Nullable
+	OrderStatus orderStatus,
+	@Nullable
+	String deliveryAddress,
+	@Nullable
+	String request
+
+) {
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
@@ -96,4 +96,8 @@ public class Order extends BaseTimeEntity {
 			orderProduct.cancel(userId);
 		}
 	}
+
+	public void updateOrderStatus(OrderStatus newStatus) {
+		this.orderStatus = newStatus;
+	}
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
@@ -18,8 +18,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -43,8 +41,7 @@ public class Order extends BaseTimeEntity {
 
 	@Id
 	@Column(name = "id")
-	@GeneratedValue(strategy = GenerationType.UUID)
-	private UUID id;
+	private UUID id = UUID.randomUUID();
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_id", nullable = false)
@@ -99,5 +96,9 @@ public class Order extends BaseTimeEntity {
 
 	public void updateOrderStatus(OrderStatus newStatus) {
 		this.orderStatus = newStatus;
+	}
+
+	public void addOrderProduct(List<OrderProduct> orderProducts){
+		this.orderProducts = orderProducts;
 	}
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
@@ -18,6 +18,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -41,7 +43,8 @@ public class Order extends BaseTimeEntity {
 
 	@Id
 	@Column(name = "id")
-	private UUID id = UUID.randomUUID();
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_id", nullable = false)

--- a/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
@@ -1,21 +1,28 @@
 package com.nbcamp.orderservice.domain.order.entity;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import com.nbcamp.orderservice.domain.common.BaseTimeEntity;
 import com.nbcamp.orderservice.domain.common.OrderStatus;
 import com.nbcamp.orderservice.domain.common.OrderType;
+import com.nbcamp.orderservice.domain.order.dto.OrderRequest;
 import com.nbcamp.orderservice.domain.store.entity.Store;
 import com.nbcamp.orderservice.domain.user.entity.User;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -35,7 +42,8 @@ public class Order extends BaseTimeEntity {
 
 	@Id
 	@Column(name = "id")
-	private UUID id = UUID.randomUUID();
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_id", nullable = false)
@@ -62,4 +70,20 @@ public class Order extends BaseTimeEntity {
 	@Column(name = "total_price", nullable = false)
 	private int totalPrice;
 
+	@OneToMany(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	private List<OrderProduct> orderProducts = new ArrayList<>();
+
+	public static Order create(OrderRequest request, Store store, User user) {
+
+		return Order.builder()
+			.store(store)
+			.user(user)
+			.orderStatus(OrderStatus.PENDING)
+			.orderType(request.type())
+			.deliveryAddress(request.address())
+			.request(request.request())
+			.totalPrice(request.price())
+			.build();
+
+	}
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
@@ -89,6 +89,12 @@ public class Order extends BaseTimeEntity {
 
 	}
 
+	public void update(OrderUpdateRequest orderUpdateRequest) {
+		this.orderStatus = orderUpdateRequest.orderStatus();
+		this.deliveryAddress = orderUpdateRequest.deliveryAddress();
+		this.request += "\n[추가 요청]: " + orderUpdateRequest.request();
+	}
+
 	public void cancelOrder(UUID userId) {
 		this.setDeletedAt(LocalDateTime.now());
 		this.setDeletedBy(userId);
@@ -96,12 +102,6 @@ public class Order extends BaseTimeEntity {
 		for (OrderProduct orderProduct : orderProducts) {
 			orderProduct.cancel(userId);
 		}
-	}
-
-	public void update(OrderUpdateRequest orderUpdateRequest) {
-		this.orderStatus = orderUpdateRequest.orderStatus();
-		this.deliveryAddress = orderUpdateRequest.deliveryAddress();
-		this.request += "\n[추가 요청]: " + orderUpdateRequest.request();
 	}
 
 	public void addOrderProduct(List<OrderProduct> orderProducts){

--- a/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
@@ -9,6 +9,7 @@ import com.nbcamp.orderservice.domain.common.BaseTimeEntity;
 import com.nbcamp.orderservice.domain.common.OrderStatus;
 import com.nbcamp.orderservice.domain.common.OrderType;
 import com.nbcamp.orderservice.domain.order.dto.OrderRequest;
+import com.nbcamp.orderservice.domain.order.dto.OrderUpdateRequest;
 import com.nbcamp.orderservice.domain.store.entity.Store;
 import com.nbcamp.orderservice.domain.user.entity.User;
 
@@ -97,8 +98,10 @@ public class Order extends BaseTimeEntity {
 		}
 	}
 
-	public void updateOrderStatus(OrderStatus newStatus) {
-		this.orderStatus = newStatus;
+	public void update(OrderUpdateRequest orderUpdateRequest) {
+		this.orderStatus = orderUpdateRequest.orderStatus();
+		this.deliveryAddress = orderUpdateRequest.deliveryAddress();
+		this.request += "\n[추가 요청]: " + orderUpdateRequest.request();
 	}
 
 	public void addOrderProduct(List<OrderProduct> orderProducts){

--- a/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/entity/Order.java
@@ -1,5 +1,6 @@
 package com.nbcamp.orderservice.domain.order.entity;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -85,5 +86,14 @@ public class Order extends BaseTimeEntity {
 			.totalPrice(request.price())
 			.build();
 
+	}
+
+	public void cancelOrder(UUID userId) {
+		this.setDeletedAt(LocalDateTime.now());
+		this.setDeletedBy(userId);
+
+		for (OrderProduct orderProduct : orderProducts) {
+			orderProduct.cancel(userId);
+		}
 	}
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/entity/OrderProduct.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/entity/OrderProduct.java
@@ -1,5 +1,6 @@
 package com.nbcamp.orderservice.domain.order.entity;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -70,6 +71,11 @@ public class OrderProduct extends BaseTimeEntity {
 					.build();
 			})
 			.collect(Collectors.toList());
+	}
+
+	public void cancel(UUID userId) {
+		this.setDeletedAt(LocalDateTime.now());
+		this.setDeletedBy(userId);
 	}
 }
 

--- a/src/main/java/com/nbcamp/orderservice/domain/order/entity/OrderProduct.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/entity/OrderProduct.java
@@ -1,12 +1,10 @@
 package com.nbcamp.orderservice.domain.order.entity;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import com.nbcamp.orderservice.domain.common.BaseTimeEntity;
-import com.nbcamp.orderservice.domain.order.dto.OrderRequest;
 import com.nbcamp.orderservice.domain.product.entity.Product;
-import com.nbcamp.orderservice.global.exception.code.ErrorCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -52,31 +50,13 @@ public class OrderProduct extends BaseTimeEntity {
 	@Column(name = "total_price", nullable = false)
 	private int totalPrice;
 
-	// public static List<OrderProduct> create(Order order, List<Product> products,
-	// 	List<OrderRequest.OrderProduct> productRequests) {
-	// 	return productRequests.stream()
-	// 		.map(productRequest -> {
-	// 			Product product = products.stream()
-	// 				.filter(p -> p.getId().equals(productRequest.productId()))
-	// 				.findFirst()
-	// 				.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_PRODUCT.getMessage()));
-	//
-	// 			return OrderProduct.builder()
-	// 				.order(order)
-	// 				.product(product)
-	// 				.quantity(productRequest.quantity())
-	// 				.totalPrice(productRequest.price())
-	// 				.build();
-	// 		})
-	// 		.collect(Collectors.toList());
-	// }
-
 	public static OrderProduct create(Order order, Product product, int quantity){
+		int totalPrice = quantity * product.getPrice();
 		return OrderProduct.builder()
 			.order(order)
 			.product(product)
 			.quantity(quantity)
-			.totalPrice(quantity * product.getPrice())
+			.totalPrice(totalPrice)
 			.build();
 	}
 

--- a/src/main/java/com/nbcamp/orderservice/domain/order/entity/OrderProduct.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/entity/OrderProduct.java
@@ -1,7 +1,5 @@
 package com.nbcamp.orderservice.domain.order.entity;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -54,23 +52,32 @@ public class OrderProduct extends BaseTimeEntity {
 	@Column(name = "total_price", nullable = false)
 	private int totalPrice;
 
-	public static List<OrderProduct> create(Order order, List<Product> products,
-		List<OrderRequest.OrderProduct> productRequests) {
-		return productRequests.stream()
-			.map(productRequest -> {
-				Product product = products.stream()
-					.filter(p -> p.getId().equals(productRequest.productId()))
-					.findFirst()
-					.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_PRODUCT.getMessage()));
+	// public static List<OrderProduct> create(Order order, List<Product> products,
+	// 	List<OrderRequest.OrderProduct> productRequests) {
+	// 	return productRequests.stream()
+	// 		.map(productRequest -> {
+	// 			Product product = products.stream()
+	// 				.filter(p -> p.getId().equals(productRequest.productId()))
+	// 				.findFirst()
+	// 				.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_PRODUCT.getMessage()));
+	//
+	// 			return OrderProduct.builder()
+	// 				.order(order)
+	// 				.product(product)
+	// 				.quantity(productRequest.quantity())
+	// 				.totalPrice(productRequest.price())
+	// 				.build();
+	// 		})
+	// 		.collect(Collectors.toList());
+	// }
 
-				return OrderProduct.builder()
-					.order(order)
-					.product(product)
-					.quantity(productRequest.quantity())
-					.totalPrice(productRequest.price())
-					.build();
-			})
-			.collect(Collectors.toList());
+	public static OrderProduct create(Order order, Product product, int quantity){
+		return OrderProduct.builder()
+			.order(order)
+			.product(product)
+			.quantity(quantity)
+			.totalPrice(quantity * product.getPrice())
+			.build();
 	}
 
 	public void cancel(UUID userId) {

--- a/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderJpaRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderJpaRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nbcamp.orderservice.domain.order.entity.Order;
 
-public interface OrderRepository extends JpaRepository<Order, UUID> {
+public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
+	boolean existsByIdAndUserId(UUID orderId, UUID userId);
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderProductJpaRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderProductJpaRepository.java
@@ -1,0 +1,10 @@
+package com.nbcamp.orderservice.domain.order.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nbcamp.orderservice.domain.order.entity.OrderProduct;
+
+public interface OrderProductJpaRepository extends JpaRepository<OrderProduct, UUID> {
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderProductRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderProductRepository.java
@@ -1,0 +1,10 @@
+package com.nbcamp.orderservice.domain.order.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nbcamp.orderservice.domain.order.entity.OrderProduct;
+
+public interface OrderProductRepository extends JpaRepository<OrderProduct, UUID> {
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderQueryRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderQueryRepository.java
@@ -1,33 +1,29 @@
 package com.nbcamp.orderservice.domain.order.repository;
 
-import java.util.Collections;
+import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
-import com.nbcamp.orderservice.domain.order.dto.OrderInfoDto;
-import com.nbcamp.orderservice.domain.order.dto.OrderProductResponse;
+import com.nbcamp.orderservice.domain.common.OrderStatus;
+import com.nbcamp.orderservice.domain.common.OrderType;
+import com.nbcamp.orderservice.domain.common.SortOption;
 import com.nbcamp.orderservice.domain.order.dto.OrderResponse;
-import com.nbcamp.orderservice.domain.order.entity.OrderProduct;
 import com.nbcamp.orderservice.domain.order.entity.QOrder;
 import com.nbcamp.orderservice.domain.order.entity.QOrderProduct;
 import com.nbcamp.orderservice.domain.product.entity.QProduct;
 import com.nbcamp.orderservice.domain.store.entity.QStore;
-import com.nbcamp.orderservice.domain.store.entity.Store;
 import com.nbcamp.orderservice.domain.user.entity.QUser;
 import com.nbcamp.orderservice.domain.user.entity.User;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -45,55 +41,18 @@ public class OrderQueryRepository {
 	QUser user = QUser.user;
 	QProduct product = QProduct.product;
 
-	public Page<OrderInfoDto> findAllOrders(Pageable pageable, String query) {
-		OrderSpecifier<?>[] orderSpecifiers = getOrderSpecifiers(pageable);
 
-		List<OrderResponse> orderResponses = jpaQueryFactory
-			.select(
-				Projections.constructor(
-					OrderResponse.class,
-					order.id,
-					order.orderStatus,
-					order.store.id,
-					order.orderType,
-					order.deliveryAddress,
-					order.request,
-					order.totalPrice
-				)
-			)
-			.from(order)
-			.leftJoin(order.store)
-			.leftJoin(order.user)
-			.leftJoin(orderProduct).on(orderProduct.order.eq(order))
-			.leftJoin(orderProduct.product).fetchJoin()
-			.where(
-				storeNameLike(query),
-				productNameLike(query)
-			)
-			.orderBy(orderSpecifiers)
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
+	public Page<OrderResponse> findByStoreOrders(
+		Pageable pageable,
+		UUID storeId,
+		OrderType orderType,
+		LocalDate startDate,
+		LocalDate endDate,
+		OrderStatus orderStatus,
+		SortOption sortOption
+	) {
 
-		Long total = jpaQueryFactory
-			.select(order.count())
-			.from(order)
-			.leftJoin(orderProduct).on(orderProduct.order.eq(order))
-			.leftJoin(orderProduct.product)
-			.where(
-				storeNameLike(query),
-				productNameLike(query)
-			)
-			.fetchOne();
-
-		return getOrderInfo(pageable, orderResponses, total);
-
-	}
-
-	public Page<OrderInfoDto> findByStore(Store store, Pageable pageable, String query) {
-		OrderSpecifier<?>[] orderSpecifiers = getOrderSpecifiers(pageable);
-
-		List<OrderResponse> orderResponses = jpaQueryFactory
+		List<OrderResponse> orderResponseList = jpaQueryFactory.query()
 			.select(
 				Projections.constructor(
 					OrderResponse.class,
@@ -108,34 +67,49 @@ public class OrderQueryRepository {
 				)
 			)
 			.from(order)
-			.leftJoin(order.user)
 			.where(
-				order.store.eq(store),
-				storeNameLike(query),
-				productNameLike(query)
+				order.store.id.eq(storeId),
+				orderTypeEquals(orderType),
+				orderPeriodCondition(startDate, endDate),
+				orderStateEquals(orderStatus)
+
 			)
-			.orderBy(orderSpecifiers)  // 정렬 조건
+			.orderBy(getOrderSpecifier(sortOption))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();
 
-		Long total = jpaQueryFactory
-			.select(order.count())
-			.from(order)
-			.where(
-				order.store.eq(store),
-				storeNameLike(query),
-				productNameLike(query)
-			)
-			.fetchOne();
+		long total = Optional.ofNullable(
+			jpaQueryFactory
+				.select(order.id.countDistinct())
+				.from(order)
+				.where(
+					order.store.id.eq(storeId),
+					orderTypeEquals(orderType),
+					orderPeriodCondition(startDate, endDate),
+					orderStateEquals(orderStatus)
+				)
+				.fetchOne()
+		).orElse(0L);
 
-		return getOrderInfo(pageable, orderResponses, total);
+
+		return new PageImpl<>(orderResponseList, pageable, total);
+
 	}
 
-	public Page<OrderInfoDto> findByUser(User user, Pageable pageable, String query) {
-		OrderSpecifier<?>[] orderSpecifiers = getOrderSpecifiers(pageable);
+	public Page<OrderResponse> findAllByUserOrder(
+		Pageable pageable,
+		User user,
+		String storeName,
+		UUID categoryId,
+		OrderType orderType,
+		LocalDate startDate,
+		LocalDate endDate,
+		OrderStatus orderStatus,
+		SortOption sortOption
+	) {
 
-		List<OrderResponse> orderResponses = jpaQueryFactory
+		List<OrderResponse> orderResponseList = jpaQueryFactory.query()
 			.select(
 				Projections.constructor(
 					OrderResponse.class,
@@ -150,108 +124,82 @@ public class OrderQueryRepository {
 				)
 			)
 			.from(order)
-			.join(order.store, store)
-			.where(order.user.eq(user),
-				storeNameLike(query),
-				JPAExpressions.selectOne()
-					.from(orderProduct)
-					.innerJoin(orderProduct.product, product)
-					.where(
-						orderProduct.order.id.eq(order.id),
-						productNameLike(query)
-					).exists()
+			.where(
+				order.user.id.eq(user.getId()),
+				storeNameContains(storeName),
+				categoryEquals(categoryId),
+				orderTypeEquals(orderType),
+				orderPeriodCondition(startDate, endDate),
+				orderStateEquals(orderStatus)
 			)
-			.orderBy(orderSpecifiers)
+			.orderBy(getOrderSpecifier(sortOption))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();
 
-		Long total = jpaQueryFactory
-			.select(order.count())
-			.from(order)
-			.where(order.user.eq(user),
-				storeNameLike(query),
-				productNameLike(query))
-			.fetchOne();
 
-		log.info("total :" + total);
-
-		return getOrderInfo(pageable, orderResponses, total);
-	}
-
-	private Page<OrderInfoDto> getOrderInfo(Pageable pageable, List<OrderResponse> orderResponses,
-		Long total) {
-
-		List<UUID> orderIds = orderResponses.stream()
-			.map(OrderResponse::orderId)
-			.collect(Collectors.toList());
-		List<OrderProductResponse> orderProductResponses = jpaQueryFactory
-			.select(
-				Projections.constructor(
-					OrderProductResponse.class,
-					orderProduct.id,
-					orderProduct.order.id,
-					orderProduct.product.id,
-					orderProduct.product.name,
-					orderProduct.quantity,
-					orderProduct.totalPrice
+		long total = Optional.ofNullable(
+			jpaQueryFactory
+				.select(order.id.countDistinct())
+				.from(order)
+				.where(
+					order.user.id.eq(user.getId()),
+					storeNameContains(storeName),
+					categoryEquals(categoryId),
+					orderTypeEquals(orderType),
+					orderPeriodCondition(startDate, endDate),
+					orderStateEquals(orderStatus)
 				)
-			)
-			.distinct()
-			.from(orderProduct)
-			.where(orderProduct.order.id.in(orderIds))
-			.fetch();
+				.fetchOne()
+		).orElse(0L);
 
-		Map<UUID, List<OrderProductResponse>> productsGroupedByOrderId = orderProductResponses.stream()
-			.collect(Collectors.groupingBy(OrderProductResponse::orderId));
 
-		List<OrderInfoDto> orderInfos = orderResponses.stream()
-			.map(orderResponse -> {
-				List<OrderProductResponse> productsForOrder = productsGroupedByOrderId.getOrDefault(
-					orderResponse.orderId(),
-					Collections.emptyList()
-				);
-				return new OrderInfoDto(orderResponse, productsForOrder);
-			})
-			.collect(Collectors.toList());
+		return new PageImpl<>(orderResponseList, pageable, total);
 
-		return new PageImpl<>(orderInfos, pageable, total != null ? total : 0L);
 	}
 
-	private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
-		String sortProperty =
-			pageable.getSort().isEmpty() ? "createdAt" : pageable.getSort().iterator().next().getProperty();
-		Sort.Direction direction =
-			pageable.getSort().isEmpty() ? Sort.Direction.DESC : pageable.getSort().iterator().next().getDirection();
 
-		OrderSpecifier<?> primaryOrderSpecifier;
-		// 정렬 조건 설정
-		if ("updatedAt".equalsIgnoreCase(sortProperty)) {
-			primaryOrderSpecifier = direction.isAscending() ? order.updatedAt.asc() : order.updatedAt.desc();
-		} else if ("user".equalsIgnoreCase(sortProperty)) {
-			primaryOrderSpecifier = direction.isAscending() ? order.user.username.asc() : order.user.username.desc();
-		} else if ("store".equalsIgnoreCase(sortProperty)) {
-			primaryOrderSpecifier = direction.isAscending() ? order.store.name.asc() : order.store.name.desc();
-		} else {
-			primaryOrderSpecifier = direction.isAscending() ? order.createdAt.asc() : order.createdAt.desc();
+	private BooleanExpression storeNameContains(String storeName) {
+		return StringUtils.hasText(storeName) ? order.store.name.containsIgnoreCase(storeName) : null;
+	}
+
+	private BooleanExpression productNameContains(String productName) {
+		return StringUtils.hasText(productName) ?
+			orderProduct.product.name.containsIgnoreCase(productName) : null;
+	}
+
+	private BooleanExpression storeUserNameContains(String storeUserName) {
+		return StringUtils.hasText(storeUserName) ?
+			order.store.name.containsIgnoreCase(storeUserName) : null;
+	}
+
+	private BooleanExpression categoryEquals(UUID categoryId) {
+		return categoryId != null ? order.store.storeCategory.any().id.eq(categoryId) : null;
+	}
+
+	private BooleanExpression orderTypeEquals(OrderType orderType) {
+		return orderType != null ? order.orderType.eq(orderType) : null;
+	}
+
+	private BooleanExpression orderPeriodCondition(LocalDate startDate, LocalDate endDate) {
+		if (startDate == null || endDate == null) {
+			return null;
 		}
-
-		return new OrderSpecifier[] {primaryOrderSpecifier, order.updatedAt.desc()};
+		return order.createdAt.between(startDate.atStartOfDay(), endDate.atTime(23, 59, 59));
 	}
 
-	private BooleanExpression storeNameLike(String query) {
-		return StringUtils.hasText(query) ? order.store.name.containsIgnoreCase(query) : null;
+	private BooleanExpression orderStateEquals(OrderStatus orderStatus){
+		return orderStatus != null ? order.orderStatus.eq(orderStatus) : null;
 	}
 
-	private BooleanExpression productNameLike(String query) {
-		return StringUtils.hasText(query) ? QOrderProduct.orderProduct.product.name.containsIgnoreCase(query) : null;
+
+	private OrderSpecifier<?> getOrderSpecifier(SortOption sortOption) {
+		return switch (sortOption) {
+			case CREATED_AT_DESC -> order.createdAt.desc();
+			case UPDATED_AT_ASC -> order.updatedAt.asc();
+			case UPDATED_AT_DESC -> order.updatedAt.desc();
+			default -> order.createdAt.asc();
+		};
 	}
 
-	public List<OrderProduct> findOrderProductsBy(UUID orderId) {
-		return jpaQueryFactory
-			.selectFrom(orderProduct)
-			.distinct()
-			.where(orderProduct.order.id.eq(orderId))
-			.fetch();
-	}
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderQueryRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderQueryRepository.java
@@ -14,6 +14,7 @@ import org.springframework.util.StringUtils;
 import com.nbcamp.orderservice.domain.common.OrderStatus;
 import com.nbcamp.orderservice.domain.common.OrderType;
 import com.nbcamp.orderservice.domain.common.SortOption;
+import com.nbcamp.orderservice.domain.order.dto.OrderProductResponse;
 import com.nbcamp.orderservice.domain.order.dto.OrderResponse;
 import com.nbcamp.orderservice.domain.order.entity.QOrder;
 import com.nbcamp.orderservice.domain.order.entity.QOrderProduct;
@@ -156,6 +157,23 @@ public class OrderQueryRepository {
 
 		return new PageImpl<>(orderResponseList, pageable, total);
 
+	}
+	public List<OrderProductResponse> findAllByOrderProductInOrder(UUID orderId){
+
+		return jpaQueryFactory.query()
+			.select(
+				Projections.constructor(
+					OrderProductResponse.class,
+					orderProduct.id,
+					orderProduct.product.id,
+					orderProduct.product.name,
+					orderProduct.quantity,
+					orderProduct.totalPrice
+				)
+			).from(orderProduct)
+			.join(orderProduct.order, order).on(order.id.eq(orderId))
+			.orderBy(orderProduct.totalPrice.desc())
+			.fetch();
 	}
 
 

--- a/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderQueryRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderQueryRepository.java
@@ -1,0 +1,249 @@
+package com.nbcamp.orderservice.domain.order.repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import com.nbcamp.orderservice.domain.order.dto.OrderInfoDto;
+import com.nbcamp.orderservice.domain.order.dto.OrderProductResponse;
+import com.nbcamp.orderservice.domain.order.dto.OrderResponse;
+import com.nbcamp.orderservice.domain.order.entity.QOrder;
+import com.nbcamp.orderservice.domain.order.entity.QOrderProduct;
+import com.nbcamp.orderservice.domain.product.entity.QProduct;
+import com.nbcamp.orderservice.domain.store.entity.QStore;
+import com.nbcamp.orderservice.domain.store.entity.Store;
+import com.nbcamp.orderservice.domain.user.entity.QUser;
+import com.nbcamp.orderservice.domain.user.entity.User;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class OrderQueryRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+	QOrder order = QOrder.order;
+	QOrderProduct orderProduct = QOrderProduct.orderProduct;
+	QStore store = QStore.store;
+	QUser user = QUser.user;
+	QProduct product = QProduct.product;
+
+	public Page<OrderInfoDto> findAllOrders(Pageable pageable, String query) {
+		OrderSpecifier<?>[] orderSpecifiers = getOrderSpecifiers(pageable);
+
+		List<OrderResponse> orderResponses = jpaQueryFactory
+			.select(
+				Projections.constructor(
+					OrderResponse.class,
+					order.id,
+					order.orderStatus,
+					order.store.id,
+					order.orderType,
+					order.deliveryAddress,
+					order.request,
+					order.totalPrice
+				)
+			)
+			.from(order)
+			.leftJoin(order.store)
+			.leftJoin(order.user)
+			.leftJoin(orderProduct).on(orderProduct.order.eq(order))
+			.leftJoin(orderProduct.product).fetchJoin()
+			.where(
+				storeNameLike(query),
+				productNameLike(query)
+			)
+			.orderBy(orderSpecifiers)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long total = jpaQueryFactory
+			.select(order.count())
+			.from(order)
+			.leftJoin(orderProduct).on(orderProduct.order.eq(order))
+			.leftJoin(orderProduct.product)
+			.where(
+				storeNameLike(query),
+				productNameLike(query)
+			)
+			.fetchOne();
+
+		return getOrderInfo(pageable, query, orderResponses, total);
+
+	}
+
+	public Page<OrderInfoDto> findByStore(Store store, Pageable pageable, String query) {
+		OrderSpecifier<?>[] orderSpecifiers = getOrderSpecifiers(pageable);
+
+		List<OrderResponse> orderResponses = jpaQueryFactory
+			.select(
+				Projections.constructor(
+					OrderResponse.class,
+					order.id,
+					order.store.id,
+					order.user.id,
+					order.orderStatus,
+					order.orderType,
+					order.deliveryAddress,
+					order.request,
+					order.totalPrice
+				)
+			)
+			.from(order)
+			.leftJoin(order.user)
+			.where(
+				order.store.eq(store),
+				storeNameLike(query),
+				productNameLike(query)
+			)
+			.orderBy(orderSpecifiers)  // 정렬 조건
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long total = jpaQueryFactory
+			.select(order.count())
+			.from(order)
+			.where(
+				order.store.eq(store),
+				storeNameLike(query),
+				productNameLike(query)
+			)
+			.fetchOne();
+
+		return getOrderInfo(pageable, query, orderResponses, total);
+	}
+
+	public Page<OrderInfoDto> findByUser(User user, Pageable pageable, String query) {
+		OrderSpecifier<?>[] orderSpecifiers = getOrderSpecifiers(pageable);
+
+		List<OrderResponse> orderResponses = jpaQueryFactory
+			.select(
+				Projections.constructor(
+					OrderResponse.class,
+					order.id,
+					order.store.id,
+					order.user.id,
+					order.orderStatus,
+					order.orderType,
+					order.deliveryAddress,
+					order.request,
+					order.totalPrice
+				)
+			)
+			.from(order)
+			.join(order.store, store)
+			.where(order.user.eq(user),
+				storeNameLike(query),
+				JPAExpressions.selectOne()
+					.from(orderProduct)
+					.innerJoin(orderProduct.product, product)
+					.where(
+						orderProduct.order.id.eq(order.id),
+						productNameLike(query)
+					).exists()
+			)
+			.orderBy(orderSpecifiers)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long total = jpaQueryFactory
+			.select(order.count())
+			.from(order)
+			.where(order.user.eq(user),
+				storeNameLike(query),
+				productNameLike(query))
+			.fetchOne();
+
+		log.info("total :" + total);
+
+		return getOrderInfo(pageable, query, orderResponses, total);
+	}
+
+	private Page<OrderInfoDto> getOrderInfo(Pageable pageable, String query, List<OrderResponse> orderResponses,
+		Long total) {
+
+		List<UUID> orderIds = orderResponses.stream()
+			.map(OrderResponse::orderId)
+			.collect(Collectors.toList());
+		List<OrderProductResponse> orderProductResponses = jpaQueryFactory
+			.select(
+				Projections.constructor(
+					OrderProductResponse.class,
+					orderProduct.id,
+					orderProduct.order.id,
+					orderProduct.product.id,
+					orderProduct.product.name,
+					orderProduct.quantity,
+					orderProduct.totalPrice
+				)
+			)
+			.distinct()
+			.from(orderProduct)
+			.where(orderProduct.order.id.in(orderIds))
+			.fetch();
+
+		Map<UUID, List<OrderProductResponse>> productsGroupedByOrderId = orderProductResponses.stream()
+			.collect(Collectors.groupingBy(OrderProductResponse::orderId));
+
+		List<OrderInfoDto> orderInfos = orderResponses.stream()
+			.map(orderResponse -> {
+				List<OrderProductResponse> productsForOrder = productsGroupedByOrderId.getOrDefault(
+					orderResponse.orderId(),
+					Collections.emptyList()
+				);
+				return new OrderInfoDto(orderResponse, productsForOrder);
+			})
+			.collect(Collectors.toList());
+
+		return new PageImpl<>(orderInfos, pageable, total != null ? total : 0L);
+	}
+
+	private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+		String sortProperty =
+			pageable.getSort().isEmpty() ? "createdAt" : pageable.getSort().iterator().next().getProperty();
+		Sort.Direction direction =
+			pageable.getSort().isEmpty() ? Sort.Direction.DESC : pageable.getSort().iterator().next().getDirection();
+
+		OrderSpecifier<?> primaryOrderSpecifier;
+		// 정렬 조건 설정
+		if ("updatedAt".equalsIgnoreCase(sortProperty)) {
+			primaryOrderSpecifier = direction.isAscending() ? order.updatedAt.asc() : order.updatedAt.desc();
+		} else if ("user".equalsIgnoreCase(sortProperty)) {
+			primaryOrderSpecifier = direction.isAscending() ? order.user.username.asc() : order.user.username.desc();
+		} else if ("store".equalsIgnoreCase(sortProperty)) {
+			primaryOrderSpecifier = direction.isAscending() ? order.store.name.asc() : order.store.name.desc();
+		} else {
+			primaryOrderSpecifier = direction.isAscending() ? order.createdAt.asc() : order.createdAt.desc();
+		}
+
+		return new OrderSpecifier[] {primaryOrderSpecifier, order.updatedAt.desc()};
+	}
+
+	private BooleanExpression storeNameLike(String query) {
+		return StringUtils.hasText(query) ? order.store.name.containsIgnoreCase(query) : null;
+	}
+
+	private BooleanExpression productNameLike(String query) {
+		return StringUtils.hasText(query) ? QOrderProduct.orderProduct.product.name.containsIgnoreCase(query) : null;
+	}
+
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderQueryRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderQueryRepository.java
@@ -86,7 +86,7 @@ public class OrderQueryRepository {
 			)
 			.fetchOne();
 
-		return getOrderInfo(pageable, query, orderResponses, total);
+		return getOrderInfo(pageable, orderResponses, total);
 
 	}
 
@@ -129,7 +129,7 @@ public class OrderQueryRepository {
 			)
 			.fetchOne();
 
-		return getOrderInfo(pageable, query, orderResponses, total);
+		return getOrderInfo(pageable, orderResponses, total);
 	}
 
 	public Page<OrderInfoDto> findByUser(User user, Pageable pageable, String query) {
@@ -176,10 +176,10 @@ public class OrderQueryRepository {
 
 		log.info("total :" + total);
 
-		return getOrderInfo(pageable, query, orderResponses, total);
+		return getOrderInfo(pageable, orderResponses, total);
 	}
 
-	private Page<OrderInfoDto> getOrderInfo(Pageable pageable, String query, List<OrderResponse> orderResponses,
+	private Page<OrderInfoDto> getOrderInfo(Pageable pageable, List<OrderResponse> orderResponses,
 		Long total) {
 
 		List<UUID> orderIds = orderResponses.stream()
@@ -245,47 +245,6 @@ public class OrderQueryRepository {
 
 	private BooleanExpression productNameLike(String query) {
 		return StringUtils.hasText(query) ? QOrderProduct.orderProduct.product.name.containsIgnoreCase(query) : null;
-	}
-
-	public OrderInfoDto findByIdWithOrderProduct(UUID orderId) {
-		OrderResponse orderResponses = jpaQueryFactory
-			.select(
-				Projections.constructor(
-					OrderResponse.class,
-					order.id,
-					order.store.id,
-					order.user.id,
-					order.orderStatus,
-					order.orderType,
-					order.deliveryAddress,
-					order.request,
-					order.totalPrice
-				)
-			)
-			.from(order)
-			.join(order.store, store).fetchJoin()
-			.join(order.user, user).fetchJoin()
-			.where(order.id.eq(orderId))
-			.fetchOne();
-
-		List<OrderProductResponse> orderProductResponses = jpaQueryFactory
-			.select(
-				Projections.constructor(
-					OrderProductResponse.class,
-					orderProduct.id,
-					orderProduct.order.id,
-					orderProduct.product.id,
-					orderProduct.product.name,
-					orderProduct.quantity,
-					orderProduct.totalPrice
-				)
-			)
-			.distinct()
-			.from(orderProduct)
-			.where(orderProduct.order.id.eq(orderId))
-			.fetch();
-
-		return new OrderInfoDto(orderResponses, orderProductResponses);
 	}
 
 	public List<OrderProduct> findOrderProductsBy(UUID orderId) {

--- a/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderQueryRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderQueryRepository.java
@@ -16,6 +16,8 @@ import com.nbcamp.orderservice.domain.common.OrderType;
 import com.nbcamp.orderservice.domain.common.SortOption;
 import com.nbcamp.orderservice.domain.order.dto.OrderProductResponse;
 import com.nbcamp.orderservice.domain.order.dto.OrderResponse;
+import com.nbcamp.orderservice.domain.order.dto.OrderSearchAdminRequest;
+import com.nbcamp.orderservice.domain.order.dto.OrderSearchCustomerRequest;
 import com.nbcamp.orderservice.domain.order.entity.QOrder;
 import com.nbcamp.orderservice.domain.order.entity.QOrderProduct;
 import com.nbcamp.orderservice.domain.product.entity.QProduct;
@@ -46,11 +48,7 @@ public class OrderQueryRepository {
 	public Page<OrderResponse> findByStoreOrders(
 		Pageable pageable,
 		UUID storeId,
-		OrderType orderType,
-		LocalDate startDate,
-		LocalDate endDate,
-		OrderStatus orderStatus,
-		SortOption sortOption
+		OrderSearchAdminRequest request
 	) {
 
 		List<OrderResponse> orderResponseList = jpaQueryFactory.query()
@@ -70,12 +68,12 @@ public class OrderQueryRepository {
 			.from(order)
 			.where(
 				order.store.id.eq(storeId),
-				orderTypeEquals(orderType),
-				orderPeriodCondition(startDate, endDate),
-				orderStateEquals(orderStatus)
+				orderTypeEquals(request.orderType()),
+				orderPeriodCondition(request.startDate(), request.endDate()),
+				orderStateEquals(request.orderStatus())
 
 			)
-			.orderBy(getOrderSpecifier(sortOption))
+			.orderBy(getOrderSpecifier(request.sortOption()))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();
@@ -86,9 +84,9 @@ public class OrderQueryRepository {
 				.from(order)
 				.where(
 					order.store.id.eq(storeId),
-					orderTypeEquals(orderType),
-					orderPeriodCondition(startDate, endDate),
-					orderStateEquals(orderStatus)
+					orderTypeEquals(request.orderType()),
+					orderPeriodCondition(request.startDate(), request.endDate()),
+					orderStateEquals(request.orderStatus())
 				)
 				.fetchOne()
 		).orElse(0L);
@@ -101,13 +99,7 @@ public class OrderQueryRepository {
 	public Page<OrderResponse> findAllByUserOrder(
 		Pageable pageable,
 		User user,
-		String storeName,
-		UUID categoryId,
-		OrderType orderType,
-		LocalDate startDate,
-		LocalDate endDate,
-		OrderStatus orderStatus,
-		SortOption sortOption
+		OrderSearchCustomerRequest request
 	) {
 
 		List<OrderResponse> orderResponseList = jpaQueryFactory.query()
@@ -127,13 +119,13 @@ public class OrderQueryRepository {
 			.from(order)
 			.where(
 				order.user.id.eq(user.getId()),
-				storeNameContains(storeName),
-				categoryEquals(categoryId),
-				orderTypeEquals(orderType),
-				orderPeriodCondition(startDate, endDate),
-				orderStateEquals(orderStatus)
+				storeNameContains(request.storeName()),
+				categoryEquals(request.categoryId()),
+				orderTypeEquals(request.orderType()),
+				orderPeriodCondition(request.startDate(), request.endDate()),
+				orderStateEquals(request.orderStatus())
 			)
-			.orderBy(getOrderSpecifier(sortOption))
+			.orderBy(getOrderSpecifier(request.sortOption()))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();
@@ -145,11 +137,11 @@ public class OrderQueryRepository {
 				.from(order)
 				.where(
 					order.user.id.eq(user.getId()),
-					storeNameContains(storeName),
-					categoryEquals(categoryId),
-					orderTypeEquals(orderType),
-					orderPeriodCondition(startDate, endDate),
-					orderStateEquals(orderStatus)
+					storeNameContains(request.storeName()),
+					categoryEquals(request.categoryId()),
+					orderTypeEquals(request.orderType()),
+					orderPeriodCondition(request.startDate(), request.endDate()),
+					orderStateEquals(request.orderStatus())
 				)
 				.fetchOne()
 		).orElse(0L);
@@ -179,16 +171,6 @@ public class OrderQueryRepository {
 
 	private BooleanExpression storeNameContains(String storeName) {
 		return StringUtils.hasText(storeName) ? order.store.name.containsIgnoreCase(storeName) : null;
-	}
-
-	private BooleanExpression productNameContains(String productName) {
-		return StringUtils.hasText(productName) ?
-			orderProduct.product.name.containsIgnoreCase(productName) : null;
-	}
-
-	private BooleanExpression storeUserNameContains(String storeUserName) {
-		return StringUtils.hasText(storeUserName) ?
-			order.store.name.containsIgnoreCase(storeUserName) : null;
 	}
 
 	private BooleanExpression categoryEquals(UUID categoryId) {

--- a/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/repository/OrderRepository.java
@@ -1,0 +1,10 @@
+package com.nbcamp.orderservice.domain.order.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nbcamp.orderservice.domain.order.entity.Order;
+
+public interface OrderRepository extends JpaRepository<Order, UUID> {
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderProductService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderProductService.java
@@ -1,0 +1,42 @@
+package com.nbcamp.orderservice.domain.order.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nbcamp.orderservice.domain.order.dto.OrderRequest;
+import com.nbcamp.orderservice.domain.order.entity.Order;
+import com.nbcamp.orderservice.domain.order.entity.OrderProduct;
+import com.nbcamp.orderservice.domain.order.repository.OrderProductJpaRepository;
+import com.nbcamp.orderservice.domain.product.entity.Product;
+import com.nbcamp.orderservice.domain.product.repository.ProductJpaRepository;
+import com.nbcamp.orderservice.global.exception.code.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OrderProductService {
+	private final OrderProductJpaRepository orderProductJpaRepository;
+	private final ProductJpaRepository productJpaRepository;
+
+	@Transactional
+	public List<OrderProduct> createOrderProducts(Order order, List<OrderRequest.OrderProduct> productList){
+		List<OrderProduct> orderProducts = new ArrayList<>();
+		for (OrderRequest.OrderProduct product : productList) {
+			Product purchasedProduct = findByProducts(String.valueOf(product));
+			orderProducts.add(OrderProduct.create(order, purchasedProduct, product.quantity()));
+		}
+		return orderProducts;
+	}
+
+
+	private Product findByProducts(String productId){
+		return productJpaRepository.findById(UUID.fromString(productId))
+			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_PRODUCT.getMessage()));
+	}
+
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderProductService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderProductService.java
@@ -27,15 +27,15 @@ public class OrderProductService {
 	public List<OrderProduct> createOrderProducts(Order order, List<OrderRequest.OrderProduct> productList){
 		List<OrderProduct> orderProducts = new ArrayList<>();
 		for (OrderRequest.OrderProduct product : productList) {
-			Product purchasedProduct = findByProducts(String.valueOf(product));
+			Product purchasedProduct = findByProducts(product.productId());
 			orderProducts.add(OrderProduct.create(order, purchasedProduct, product.quantity()));
 		}
 		return orderProducts;
 	}
 
 
-	private Product findByProducts(String productId){
-		return productJpaRepository.findById(UUID.fromString(productId))
+	private Product findByProducts(UUID productId){
+		return productJpaRepository.findById(productId)
 			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_PRODUCT.getMessage()));
 	}
 

--- a/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
@@ -171,7 +171,7 @@ public class OrderService {
 		Order order = orderRepository.findById(orderId)
 			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_ORDER.getMessage()));
 
-		validateOrderStatus(order.getOrderStatus(), newStatus);
+		validateOrderStatus(order.getOrderStatus());
 
 		order.updateOrderStatus(newStatus);
 		orderRepository.save(order);
@@ -189,7 +189,7 @@ public class OrderService {
 		);
 	}
 
-	private void validateOrderStatus(OrderStatus currentStatus, OrderStatus newStatus) {
+	private void validateOrderStatus(OrderStatus currentStatus) {
 		if (currentStatus == OrderStatus.COMPLETED || currentStatus == OrderStatus.CANCELLED) {
 			throw new IllegalArgumentException(ErrorCode.INVALID_ORDER_STATUS.getMessage());
 		}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
@@ -27,7 +27,6 @@ import com.nbcamp.orderservice.domain.order.entity.Order;
 import com.nbcamp.orderservice.domain.order.entity.OrderProduct;
 import com.nbcamp.orderservice.domain.order.repository.OrderJpaRepository;
 import com.nbcamp.orderservice.domain.order.repository.OrderQueryRepository;
-import com.nbcamp.orderservice.domain.product.repository.ProductJpaRepository;
 import com.nbcamp.orderservice.domain.store.entity.Store;
 import com.nbcamp.orderservice.domain.store.repository.StoreJpaRepository;
 import com.nbcamp.orderservice.domain.user.entity.User;
@@ -43,7 +42,6 @@ public class OrderService {
 
 	private final OrderJpaRepository orderJpaRepository;
 	private final StoreJpaRepository storeJpaRepository;
-	private final ProductJpaRepository productJpaRepository;
 	private final OrderQueryRepository orderQueryRepository;
 	private final OrderProductService orderProductService;
 	private final CategoryJpaRepository categoryJpaRepository;

--- a/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
@@ -1,0 +1,89 @@
+package com.nbcamp.orderservice.domain.order.service;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nbcamp.orderservice.domain.common.UserRole;
+import com.nbcamp.orderservice.domain.order.dto.OrderRequest;
+import com.nbcamp.orderservice.domain.order.dto.OrderResponse;
+import com.nbcamp.orderservice.domain.order.entity.Order;
+import com.nbcamp.orderservice.domain.order.entity.OrderProduct;
+import com.nbcamp.orderservice.domain.order.repository.OrderProductRepository;
+import com.nbcamp.orderservice.domain.order.repository.OrderRepository;
+import com.nbcamp.orderservice.domain.product.entity.Product;
+import com.nbcamp.orderservice.domain.product.repository.ProductJpaRepository;
+import com.nbcamp.orderservice.domain.store.entity.Store;
+import com.nbcamp.orderservice.domain.store.repository.StoreJpaRepository;
+import com.nbcamp.orderservice.domain.user.entity.User;
+import com.nbcamp.orderservice.global.exception.code.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderService {
+
+	private final OrderRepository orderRepository;
+	private final OrderProductRepository orderProductRepository;
+	private final StoreJpaRepository storeJpaRepository;
+	private final ProductJpaRepository productJpaRepository;
+
+	@Transactional
+	public OrderResponse createOrder(OrderRequest request, User user) {
+		Store store = getStoreById(request.storeId());
+		validateUserRoleForCreateOrder(user);
+
+		Order order = Order.create(request, store, user);
+		orderRepository.save(order);
+
+		List<Product> products = getProductsFromRequest(request.products());
+		List<OrderProduct> orderProducts = OrderProduct.create(order, products, request.products());
+		orderProductRepository.saveAll(orderProducts);
+
+		return new OrderResponse(
+			order.getId(),
+			order.getOrderStatus(),
+			order.getStore().getId(),
+			order.getOrderType(),
+			order.getDeliveryAddress(),
+			order.getRequest(),
+			order.getTotalPrice(),
+			orderProducts.stream()
+				.map(orderProduct -> new OrderResponse.OrderProductResponse(
+					orderProduct.getId(),
+					orderProduct.getProduct().getId(),
+					orderProduct.getQuantity(),
+					orderProduct.getTotalPrice()
+				))
+				.collect(Collectors.toList())
+		);
+	}
+
+	private Store getStoreById(UUID storeId) {
+		return storeJpaRepository.findById(storeId)
+			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_STORE.getMessage()));
+	}
+
+	private void validateUserRoleForCreateOrder(User user) {
+		if (user.getUserRole() != UserRole.CUSTOMER && user.getUserRole() != UserRole.OWNER) {
+			throw new IllegalArgumentException(ErrorCode.NO_PERMISSION_TO_CREATE_ORDER.getMessage());
+		}
+	}
+
+	private Product getProductById(String productId) {
+		return productJpaRepository.findById(UUID.fromString(productId))
+			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_PRODUCT.getMessage()));
+	}
+
+	private List<Product> getProductsFromRequest(List<OrderRequest.OrderProduct> productRequests) {
+		return productRequests.stream()
+			.map(productRequest -> getProductById(productRequest.productId().toString()))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
@@ -135,4 +135,35 @@ public class OrderService {
 		order.cancelOrder(user.getId());
 	}
 
+	public OrderInfoDto getOrderDetail(UUID orderId) {
+		Order order = orderRepository.findById(orderId)
+			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_ORDER.getMessage()));
+
+		List<OrderProduct> orderProducts = orderQueryRepository.findOrderProductsBy(orderId);
+
+		OrderResponse orderResponse = new OrderResponse(
+			order.getId(),
+			order.getStore().getId(),
+			order.getUser().getId(),
+			order.getOrderStatus(),
+			order.getOrderType(),
+			order.getDeliveryAddress(),
+			order.getRequest(),
+			order.getTotalPrice()
+		);
+
+		List<OrderProductResponse> orderProductResponses = orderProducts.stream()
+			.map(orderProduct -> new OrderProductResponse(
+				orderProduct.getId(),
+				orderProduct.getOrder().getId(),
+				orderProduct.getProduct().getId(),
+				orderProduct.getProduct().getName(),
+				orderProduct.getQuantity(),
+				orderProduct.getTotalPrice()
+			))
+			.toList();
+
+		return new OrderInfoDto(orderResponse, orderProductResponses);
+	}
+
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
@@ -27,7 +27,6 @@ import com.nbcamp.orderservice.domain.order.entity.Order;
 import com.nbcamp.orderservice.domain.order.entity.OrderProduct;
 import com.nbcamp.orderservice.domain.order.repository.OrderJpaRepository;
 import com.nbcamp.orderservice.domain.order.repository.OrderQueryRepository;
-import com.nbcamp.orderservice.domain.product.entity.Product;
 import com.nbcamp.orderservice.domain.product.repository.ProductJpaRepository;
 import com.nbcamp.orderservice.domain.store.entity.Store;
 import com.nbcamp.orderservice.domain.store.repository.StoreJpaRepository;
@@ -211,8 +210,6 @@ public class OrderService {
 		}
 	}
 
-
-
 	private Store getStoreById(UUID storeId) {
 		return storeJpaRepository.findById(storeId)
 			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_STORE.getMessage()));
@@ -222,11 +219,6 @@ public class OrderService {
 		if (user.getUserRole() != UserRole.CUSTOMER && user.getUserRole() != UserRole.OWNER) {
 			throw new IllegalArgumentException(ErrorCode.NO_PERMISSION_TO_CREATE_ORDER.getMessage());
 		}
-	}
-
-	private Product getProductById(String productId) {
-		return productJpaRepository.findById(UUID.fromString(productId))
-			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_PRODUCT.getMessage()));
 	}
 
 

--- a/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/order/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.nbcamp.orderservice.domain.order.service;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -11,7 +12,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.nbcamp.orderservice.domain.category.repository.CategoryJpaRepository;
 import com.nbcamp.orderservice.domain.common.OrderStatus;
+import com.nbcamp.orderservice.domain.common.OrderType;
+import com.nbcamp.orderservice.domain.common.SortOption;
 import com.nbcamp.orderservice.domain.common.UserRole;
 import com.nbcamp.orderservice.domain.order.dto.OrderInfoResponse;
 import com.nbcamp.orderservice.domain.order.dto.OrderProductResponse;
@@ -26,6 +30,7 @@ import com.nbcamp.orderservice.domain.product.entity.Product;
 import com.nbcamp.orderservice.domain.product.repository.ProductJpaRepository;
 import com.nbcamp.orderservice.domain.store.entity.Store;
 import com.nbcamp.orderservice.domain.store.repository.StoreJpaRepository;
+import com.nbcamp.orderservice.domain.store.repository.StoreQueryRepository;
 import com.nbcamp.orderservice.domain.user.entity.User;
 import com.nbcamp.orderservice.global.exception.code.ErrorCode;
 
@@ -43,18 +48,20 @@ public class OrderService {
 	private final ProductJpaRepository productJpaRepository;
 	private final OrderQueryRepository orderQueryRepository;
 	private final OrderProductService orderProductService;
-
+	private final StoreQueryRepository storeQueryRepository;
+	private final CategoryJpaRepository categoryJpaRepository;
 
 	@Transactional
 	public OrderInfoResponse createOrder(OrderRequest request, User user) {
 		validateUserRoleForCreateOrder(user);
+		// TODO: 2024-11-15  주소 검증로직추가 (오프라인 온라인) 오프라인은 주소가 없음
 		Store store = getStoreById(request.storeId());
 
 		Order order = Order.create(request, store, user);
-		orderRepository.save(order);
 
 		List<OrderProduct> orderProducts = orderProductService.createOrderProducts(order, request.products());
 		order.addOrderProduct(orderProducts);
+		orderRepository.save(order);
 
 		OrderResponse orderResponse = new OrderResponse(
 			order.getId(),
@@ -80,19 +87,55 @@ public class OrderService {
 		return new OrderInfoResponse(orderResponse, orderProductResponses);
 	}
 
-	public Page<OrderInfoResponse> getOrders(Pageable pageable, User user, String query) {
-		UserRole userRole = user.getUserRole();
-
-		if (userRole == UserRole.OWNER) {
-			Store store = storeJpaRepository.findByUser(user)
-				.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_STORE.getMessage()));
-			return orderQueryRepository.findByStore(store, pageable, query);
-		} else if (userRole == UserRole.CUSTOMER) {
-			return orderQueryRepository.findByUser(user, pageable, query);
-		} else {
-			return orderQueryRepository.findAllOrders(pageable, query);
-		}
+	@Transactional(readOnly = true)
+	public Page<OrderResponse> getOrdersAdmin(
+		Pageable pageable,
+		UUID storeId,
+		OrderType orderType,
+		LocalDate startDate,
+		LocalDate endDate,
+		OrderStatus orderStatus,
+		SortOption sortOption
+	) {
+		return orderQueryRepository.findByStoreOrders(
+			pageable,
+			storeId,
+			orderType,
+			startDate,
+			endDate,
+			orderStatus,
+			sortOption
+		);
 	}
+
+	@Transactional(readOnly = true)
+	public Page<OrderResponse> getOrdersCustomer(
+		Pageable pageable,
+		User user,
+		String storeName,
+		UUID categoryId,
+		OrderType orderType,
+		LocalDate startDate,
+		LocalDate endDate,
+		OrderStatus orderStatus,
+		SortOption sortOption
+	) {
+		if(categoryId != null){
+			existsByCategory(categoryId);
+		}
+		return orderQueryRepository.findAllByUserOrder(
+			pageable,
+			user,
+			storeName,
+			categoryId,
+			orderType,
+			startDate,
+			endDate,
+			orderStatus,
+			sortOption
+		);
+	}
+
 
 	private Store getStoreById(UUID storeId) {
 		return storeJpaRepository.findById(storeId)
@@ -164,6 +207,7 @@ public class OrderService {
 			.toList();
 
 		return new OrderInfoResponse(orderResponse, orderProductResponses);
+		return null;
 	}
 
 	public OrderResponse updateOrderStatus(UUID orderId, OrderStatus newStatus) {
@@ -191,6 +235,13 @@ public class OrderService {
 	private void validateOrderStatus(OrderStatus currentStatus) {
 		if (currentStatus == OrderStatus.COMPLETED || currentStatus == OrderStatus.CANCELLED) {
 			throw new IllegalArgumentException(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+		}
+	}
+
+
+	private void existsByCategory(UUID categoryId){
+		if(!categoryJpaRepository.existsById(categoryId)){
+			throw new IllegalArgumentException(ErrorCode.NOT_FOUND_CATEGORY.getMessage());
 		}
 	}
 

--- a/src/main/java/com/nbcamp/orderservice/domain/product/api/ProductController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/product/api/ProductController.java
@@ -62,7 +62,7 @@ public class ProductController {
 			productService.getAllProducts(storeId, page - 1, size, sortOption, userDetails.getUser()));
 	}
 
-	@GetMapping("/stores/{storeId}/products")
+	@GetMapping("/stores/{storeId}/products/search")
 	public ResponseEntity<CommonResponse<Page<ProductResponse>>> searchProducts(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@RequestParam("page") int page,

--- a/src/main/java/com/nbcamp/orderservice/domain/review/service/ReviewService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/review/service/ReviewService.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.nbcamp.orderservice.domain.common.OrderStatus;
 import com.nbcamp.orderservice.domain.common.UserRole;
 import com.nbcamp.orderservice.domain.order.entity.Order;
-import com.nbcamp.orderservice.domain.order.repository.OrderRepository;
+import com.nbcamp.orderservice.domain.order.repository.OrderJpaRepository;
 import com.nbcamp.orderservice.domain.review.dto.ReviewCursorResponse;
 import com.nbcamp.orderservice.domain.review.dto.ReviewDetailsCursorResponse;
 import com.nbcamp.orderservice.domain.review.dto.ReviewRequest;
@@ -34,7 +34,7 @@ public class ReviewService {
 
 	private final ReviewJpaRepository reviewJpaRepository;
 	private final ReviewQueryRepository reviewQueryRepository;
-	private final OrderRepository orderRepository;
+	private final OrderJpaRepository orderJpaRepository;
 	private final StoreService storeService;
 	private final UserService userService;
 
@@ -140,7 +140,7 @@ public class ReviewService {
 
 
 	private Order findByOrderId(String orderId) {
-		return orderRepository.findById(UUID.fromString(orderId))
+		return orderJpaRepository.findById(UUID.fromString(orderId))
 			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_ORDER.getMessage()));
 	}
 

--- a/src/main/java/com/nbcamp/orderservice/domain/store/repository/StoreJpaRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/repository/StoreJpaRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.nbcamp.orderservice.domain.store.entity.Store;
 
 public interface StoreJpaRepository extends JpaRepository<Store, UUID> {
+
+	boolean existsByIdAndUserId(UUID storeId, UUID userId);
 }

--- a/src/main/java/com/nbcamp/orderservice/global/config/PageableConfig.java
+++ b/src/main/java/com/nbcamp/orderservice/global/config/PageableConfig.java
@@ -1,0 +1,18 @@
+package com.nbcamp.orderservice.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.nbcamp.orderservice.domain.common.CustomPageableArgumentResolver;
+
+@Configuration
+public class PageableConfig implements WebMvcConfigurer {
+
+	@Override
+	public  void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers){
+		resolvers.add(new CustomPageableArgumentResolver());
+	}
+}

--- a/src/main/java/com/nbcamp/orderservice/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/nbcamp/orderservice/global/exception/code/ErrorCode.java
@@ -76,8 +76,12 @@ public enum ErrorCode {
 	/**
 	 * PRODUCT
 	 */
-	NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다.");
+	NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
 
+	/**
+	 * ORDER
+	 */
+	NO_PERMISSION_TO_CREATE_ORDER(HttpStatus.BAD_REQUEST, "주문 생성권한이 없습니다.");
 	private final HttpStatus httpStatus;
 	private final String message;
 

--- a/src/main/java/com/nbcamp/orderservice/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/nbcamp/orderservice/global/exception/code/ErrorCode.java
@@ -81,7 +81,11 @@ public enum ErrorCode {
 	/**
 	 * ORDER
 	 */
-	NO_PERMISSION_TO_CREATE_ORDER(HttpStatus.BAD_REQUEST, "주문 생성권한이 없습니다.");
+	NO_PERMISSION_TO_CREATE_ORDER(HttpStatus.BAD_REQUEST, "주문 생성권한이 없습니다."),
+	NOT_FOUND_Order(HttpStatus.BAD_REQUEST, "주문정보를 찾을 수 없습니다."),
+	ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 주문정보입니다."),
+	CANCELLATION_TIME_EXCEEDED(HttpStatus.BAD_REQUEST, "주문 취소 가능 시간이 초과되었습니다. 주문 생성 후 5분 이내에만 취소할 수 있습니다.");
+
 	private final HttpStatus httpStatus;
 	private final String message;
 

--- a/src/main/java/com/nbcamp/orderservice/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/nbcamp/orderservice/global/exception/code/ErrorCode.java
@@ -82,7 +82,7 @@ public enum ErrorCode {
 	 * ORDER
 	 */
 	NO_PERMISSION_TO_CREATE_ORDER(HttpStatus.BAD_REQUEST, "주문 생성권한이 없습니다."),
-	NOT_FOUND_Order(HttpStatus.BAD_REQUEST, "주문정보를 찾을 수 없습니다."),
+	NOT_FOUND_ORDER(HttpStatus.BAD_REQUEST, "주문정보를 찾을 수 없습니다."),
 	ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 주문정보입니다."),
 	CANCELLATION_TIME_EXCEEDED(HttpStatus.BAD_REQUEST, "주문 취소 가능 시간이 초과되었습니다. 주문 생성 후 5분 이내에만 취소할 수 있습니다.");
 

--- a/src/main/java/com/nbcamp/orderservice/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/nbcamp/orderservice/global/exception/code/ErrorCode.java
@@ -84,7 +84,9 @@ public enum ErrorCode {
 	NO_PERMISSION_TO_CREATE_ORDER(HttpStatus.BAD_REQUEST, "주문 생성권한이 없습니다."),
 	NOT_FOUND_ORDER(HttpStatus.BAD_REQUEST, "주문정보를 찾을 수 없습니다."),
 	ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 주문정보입니다."),
-	CANCELLATION_TIME_EXCEEDED(HttpStatus.BAD_REQUEST, "주문 취소 가능 시간이 초과되었습니다. 주문 생성 후 5분 이내에만 취소할 수 있습니다.");
+	CANCELLATION_TIME_EXCEEDED(HttpStatus.BAD_REQUEST, "주문 취소 가능 시간이 초과되었습니다. 주문 생성 후 5분 이내에만 취소할 수 있습니다."),
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "잘못된 접근입니다."),
+	INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 상태입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;


### PR DESCRIPTION
작업내용 - 주문도메인 기능 구현

- 주문 Dto 추가
- 주문 등록 기능 구현
- 주문 취소 기능 구현
- 주문 상세 조회 기능 구현
- 주문 조회(페이징, 필터링-매장별, 사용자별, 정렬-생성일,수정일,매장이름,사용자이름) 기능 구현
