### PR TITLE
refactor: 매장 기능 리팩토링

### DIFF
--- a/src/main/java/com/nbcamp/orderservice/domain/category/repository/CategoryQueryRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/category/repository/CategoryQueryRepository.java
@@ -2,6 +2,7 @@ package com.nbcamp.orderservice.domain.category.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
 
@@ -19,10 +20,10 @@ public class CategoryQueryRepository {
 
 	QCategory qCategory = QCategory.category1;
 
-	public Optional<List<Category>> findAllCategoryByCategoryId(List<String> categoryList){
+	public Optional<List<Category>> findAllCategoryByCategoryId(List<UUID> categoryList){
 		List<Category> categories = jpaQueryFactory
 			.selectFrom(qCategory)
-			.where(qCategory.category.in(categoryList)).fetch();
+			.where(qCategory.id.in(categoryList)).fetch();
 
 		if(categories.size() != categoryList.size()){
 			return Optional.empty();

--- a/src/main/java/com/nbcamp/orderservice/domain/category/service/CategoryService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/category/service/CategoryService.java
@@ -76,10 +76,6 @@ public class CategoryService {
 			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_FOUND_CATEGORY.getMessage()));
 	}
 
-	public List<Category> findCategoriesByNames(List<String> categoryList){
-		return categoryQueryRepository.findAllCategoryByCategoryId(categoryList)
-			.orElseThrow(()-> new IllegalArgumentException(ErrorCode.NOT_FOUND_CATEGORY.getMessage()));
-	}
 
 	private void checkMasterUserRole(User user) {
 		if (user.getUserRole().equals(UserRole.CUSTOMER)

--- a/src/main/java/com/nbcamp/orderservice/domain/review/api/ReviewController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/review/api/ReviewController.java
@@ -1,5 +1,7 @@
 package com.nbcamp.orderservice.domain.review.api;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
@@ -45,7 +47,7 @@ public class ReviewController {
 
 	@GetMapping("/stores/{storeId}/orders/reviews")
 	public ResponseEntity<CommonResponse<Slice<ReviewCursorResponse>>> getCursorReview(
-		@PathVariable String storeId,
+		@PathVariable UUID storeId,
 		Pageable pageable
 	) {
 		return CommonResponse.success(SuccessCode.SUCCESS, reviewService.getCursorReview(storeId, pageable));

--- a/src/main/java/com/nbcamp/orderservice/domain/review/service/ReviewService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/review/service/ReviewService.java
@@ -55,7 +55,7 @@ public class ReviewService {
 	}
 
 	@Transactional(readOnly = true)
-	public Slice<ReviewCursorResponse> getCursorReview(String storeId, Pageable pageable) {
+	public Slice<ReviewCursorResponse> getCursorReview(UUID storeId, Pageable pageable) {
 		Store store = storeService.findById(storeId);
 		return reviewQueryRepository.getAllReviewInStore(store, pageable);
 

--- a/src/main/java/com/nbcamp/orderservice/domain/store/api/StoreController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/api/StoreController.java
@@ -1,5 +1,7 @@
 package com.nbcamp.orderservice.domain.store.api;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
@@ -7,14 +9,15 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nbcamp.orderservice.domain.store.dto.StoreCursorRequest;
 import com.nbcamp.orderservice.domain.store.dto.StoreCursorResponse;
 import com.nbcamp.orderservice.domain.store.dto.StoreDetailsResponse;
 import com.nbcamp.orderservice.domain.store.dto.StoreRequest;
@@ -45,19 +48,18 @@ public class StoreController {
 	}
 
 	@GetMapping("/stores/{storeId}")
-	public ResponseEntity<CommonResponse<StoreDetailsResponse>> getDetailsStore(@PathVariable String storeId) {
+	public ResponseEntity<CommonResponse<StoreDetailsResponse>> getDetailsStore(@PathVariable UUID storeId) {
 		return CommonResponse.success(SuccessCode.SUCCESS, storeService.getDetailsStore(storeId));
 	}
 
 	@GetMapping("/stores")
 	public ResponseEntity<CommonResponse<Slice<StoreCursorResponse>>> getCursorStore(
-		@RequestParam(required = false) String cursorId,
-		@RequestParam(required = false) String category,
-		@RequestParam String address,
-		Pageable pageable
+		@Valid @ModelAttribute StoreCursorRequest storeCursorRequest,
+		Pageable pageable,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
 	) {
 		return CommonResponse.success(SuccessCode.SUCCESS,
-			storeService.getCursorStore(cursorId, category, address, pageable));
+			storeService.getCursorStore(storeCursorRequest, pageable, userDetails.getUser()));
 	}
 
 	@PreAuthorize("hasAnyRole('MASTER')")

--- a/src/main/java/com/nbcamp/orderservice/domain/store/api/StoreController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/api/StoreController.java
@@ -65,21 +65,19 @@ public class StoreController {
 	@PreAuthorize("hasAnyRole('MASTER')")
 	@PutMapping("/stores/{storeId}")
 	public ResponseEntity<CommonResponse<StoreResponse>> updateStore(
-		@AuthenticationPrincipal UserDetailsImpl userDetails,
-		@PathVariable String storeId,
-		@RequestBody StoreRequest storeRequest
+		@PathVariable UUID storeId,
+		@Valid @RequestBody StoreRequest storeRequest
 	) {
 		return CommonResponse.success(SuccessCode.SUCCESS_UPDATE,
-			storeService.updateStore(userDetails.getUser(), storeId, storeRequest));
+			storeService.updateStore(storeId, storeRequest));
 	}
 
 	@PreAuthorize("hasAnyRole('MASTER')")
 	@DeleteMapping("/stores/{storeId}")
 	public ResponseEntity<CommonResponse<Void>> deleteStore(
-		@AuthenticationPrincipal UserDetailsImpl userDetails,
-		@PathVariable String storeId
+		@PathVariable UUID storeId
 	){
-		storeService.deletedStore(userDetails.getUser(), storeId);
+		storeService.deletedStore(storeId);
 		return CommonResponse.success(SuccessCode.SUCCESS_DELETE);
 	}
 

--- a/src/main/java/com/nbcamp/orderservice/domain/store/api/StoreController.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/api/StoreController.java
@@ -3,6 +3,7 @@ package com.nbcamp.orderservice.domain.store.api;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,6 +24,7 @@ import com.nbcamp.orderservice.global.exception.code.SuccessCode;
 import com.nbcamp.orderservice.global.response.CommonResponse;
 import com.nbcamp.orderservice.global.security.UserDetailsImpl;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -32,14 +34,14 @@ public class StoreController {
 
 	private final StoreService storeService;
 
+	@PreAuthorize("hasAnyRole('MASTER')")
 	@PostMapping("/stores/users/{userId}")
 	public ResponseEntity<CommonResponse<StoreResponse>> createStore(
-		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@PathVariable String userId,
-		@RequestBody StoreRequest storeRequest
+		@Valid @RequestBody StoreRequest storeRequest
 	) {
 		return CommonResponse.success(
-			SuccessCode.SUCCESS_INSERT, storeService.createStore(userId, storeRequest, userDetails.getUser()));
+			SuccessCode.SUCCESS_INSERT, storeService.createStore(userId, storeRequest));
 	}
 
 	@GetMapping("/stores/{storeId}")
@@ -58,6 +60,7 @@ public class StoreController {
 			storeService.getCursorStore(cursorId, category, address, pageable));
 	}
 
+	@PreAuthorize("hasAnyRole('MASTER')")
 	@PutMapping("/stores/{storeId}")
 	public ResponseEntity<CommonResponse<StoreResponse>> updateStore(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -68,6 +71,7 @@ public class StoreController {
 			storeService.updateStore(userDetails.getUser(), storeId, storeRequest));
 	}
 
+	@PreAuthorize("hasAnyRole('MASTER')")
 	@DeleteMapping("/stores/{storeId}")
 	public ResponseEntity<CommonResponse<Void>> deleteStore(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreCursorRequest.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreCursorRequest.java
@@ -1,0 +1,27 @@
+package com.nbcamp.orderservice.domain.store.dto;
+
+import java.util.UUID;
+
+import com.nbcamp.orderservice.domain.common.SortOption;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record StoreCursorRequest(
+	UUID storeId,
+	UUID categoryId,
+	@Size(max = 200, message = "주소는 200자 이내로 작성해 주세요.")
+	@Pattern(
+		regexp = "([가-힣]+(특별시|광역시|도))\\s([가-힣]+구)",
+		message = "주소는 올바른 형식으로 입력해 주세요. 예: 서울특별시 강남구"
+	)
+	String address,
+	SortOption sortOption
+) {
+	public StoreCursorRequest(UUID storeId, UUID categoryId, String address, SortOption sortOption) {
+		this.storeId = storeId;
+		this.categoryId = categoryId;
+		this.address = address;
+		this.sortOption = sortOption != null ? sortOption : SortOption.CREATED_AT_ASC; // 기본 값 설정
+	}
+}

--- a/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreCursorRequest.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreCursorRequest.java
@@ -12,7 +12,7 @@ public record StoreCursorRequest(
 	UUID categoryId,
 	@Size(max = 200, message = "주소는 200자 이내로 작성해 주세요.")
 	@Pattern(
-		regexp = "([가-힣]+(특별시|광역시|도))\\s([가-힣]+구)",
+		regexp = "([가-힣]+(특별시|광역시|도))\\s([가-힣]+구)(.*)?",
 		message = "주소는 올바른 형식으로 입력해 주세요. 예: 서울특별시 강남구"
 	)
 	String address,

--- a/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreDetailsResponse.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreDetailsResponse.java
@@ -2,6 +2,8 @@ package com.nbcamp.orderservice.domain.store.dto;
 
 import java.util.UUID;
 
+import com.nbcamp.orderservice.domain.store.entity.Store;
+
 public record StoreDetailsResponse(
 	UUID storeId,
 	String ownerName,
@@ -9,4 +11,13 @@ public record StoreDetailsResponse(
 	String address,
 	String callNumber
 ) {
+	public StoreDetailsResponse(Store store){
+		this(
+			store.getId(),
+			store.getUser().getUsername(),
+			store.getName(),
+			store.getAddress(),
+			store.getCallNumber()
+		);
+	}
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreRequest.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreRequest.java
@@ -17,8 +17,10 @@ public record StoreRequest(
 	List<UUID> category,
 	@Size(max = 200, message = "주소는 200자 이내로 작성해 주세요.")
 	@NotNull(message = "주소는 필수 입력값입니다.")
-	@Pattern(regexp = "([가-힣]+(특별시|광역시|도))\\s([가-힣]+구)",
-		message = "주소는 올바른 형식으로 입력해 주세요. 예: 서울특별시 강남구")
+	@Pattern(
+		regexp = "([가-힣]+(특별시|광역시|도))\\s([가-힣]+구)",
+		message = "주소는 올바른 형식으로 입력해 주세요. 예: 서울특별시 강남구"
+	)
 	String address,
 	@NotNull(message = "매장 전화번호는 필수입니다.")
 	@Pattern(

--- a/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreRequest.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreRequest.java
@@ -18,7 +18,7 @@ public record StoreRequest(
 	@Size(max = 200, message = "주소는 200자 이내로 작성해 주세요.")
 	@NotNull(message = "주소는 필수 입력값입니다.")
 	@Pattern(
-		regexp = "([가-힣]+(특별시|광역시|도))\\s([가-힣]+구)",
+		regexp = "([가-힣]+(특별시|광역시|도))\\s([가-힣]+구)(.*)?",
 		message = "주소는 올바른 형식으로 입력해 주세요. 예: 서울특별시 강남구"
 	)
 	String address,

--- a/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreRequest.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreRequest.java
@@ -1,11 +1,30 @@
 package com.nbcamp.orderservice.domain.store.dto;
 
 import java.util.List;
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 public record StoreRequest(
+	@Size(max = 50)
+	@NotNull(message = "매장명은 필수입니다")
 	String name,
-	List<String> category,
+	@NotNull(message = "카테고리 정보는 필수입니다.")
+	@NotEmpty(message = "카테고리 정보는 하나 이상 입력해야 합니다.")
+	List<UUID> category,
+	@Size(max = 200, message = "주소는 200자 이내로 작성해 주세요.")
+	@NotNull(message = "주소는 필수 입력값입니다.")
+	@Pattern(regexp = "([가-힣]+(특별시|광역시|도))\\s([가-힣]+구)",
+		message = "주소는 올바른 형식으로 입력해 주세요. 예: 서울특별시 강남구")
 	String address,
+	@NotNull(message = "매장 전화번호는 필수입니다.")
+	@Pattern(
+		regexp = "(0\\d{1,2})-(\\d{3,4})-(\\d{4})",
+		message = "전화번호는 올바른 형식으로 입력해 주세요. 예: 02-123-4567 또는 041-1234-5678"
+	)
 	String callNumber
 ) {
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreResponse.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/dto/StoreResponse.java
@@ -3,13 +3,27 @@ package com.nbcamp.orderservice.domain.store.dto;
 import java.util.List;
 import java.util.UUID;
 
+import com.nbcamp.orderservice.domain.store.entity.Store;
+
 public record StoreResponse(
 	UUID storeId,
 	UUID userId,
 	String ownerName,
 	String name,
 	String address,
-	List<String> category,
+	List<UUID> category,
 	String callNumber
 ) {
+	public StoreResponse(Store store){
+		this(
+			store.getId(),
+			store.getUser().getId(),
+			store.getUser().getUsername(),
+			store.getName(),
+			store.getAddress(),
+			store.getStoreCategory().stream().map(storeCategory -> storeCategory.getCategory().getId()).toList(),
+			store.getCallNumber()
+		);
+	}
+
 }

--- a/src/main/java/com/nbcamp/orderservice/domain/store/repository/StoreQueryRepository.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/repository/StoreQueryRepository.java
@@ -8,10 +8,14 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
+import com.nbcamp.orderservice.domain.common.SortOption;
+import com.nbcamp.orderservice.domain.common.UserRole;
 import com.nbcamp.orderservice.domain.store.dto.StoreCursorResponse;
 import com.nbcamp.orderservice.domain.store.entity.QStore;
-import com.querydsl.core.BooleanBuilder;
+import com.nbcamp.orderservice.domain.user.entity.User;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -25,21 +29,13 @@ public class StoreQueryRepository {
 	QStore qStore = QStore.store;
 
 	public Slice<StoreCursorResponse> findAllByStorePageable(
-		String cursorId,
-		String category,
+		UUID storeId,
+		UUID categoryId,
 		String address,
-		Pageable pageable
+		SortOption sortOption,
+		Pageable pageable,
+		User user
 	) {
-		BooleanBuilder cursorFilter = new BooleanBuilder();
-
-		if (cursorId != null) {
-			UUID cursorUUID = UUID.fromString(cursorId);
-			cursorFilter.and(qStore.id.gt(cursorUUID));
-		}
-
-		if (category != null) {
-			cursorFilter.and(qStore.storeCategory.any().category.category.eq(category));
-		}
 
 		List<StoreCursorResponse> storeList = jpaQueryFactory.query()
 			.select(
@@ -52,14 +48,13 @@ public class StoreQueryRepository {
 			)
 			.from(qStore)
 			.where(
-				cursorFilter,
-				qStore.address.contains(address),
-				qStore.deletedAt.isNull().and(qStore.deletedBy.isNull())
+				cursorIdFiltering(storeId),
+				categoryEquals(categoryId),
+				addressContains(address), // 특정 주소 기준
+				roleBasedDeleteFilter(user.getUserRole())
 				)
 			.orderBy(
-				qStore.storeGrade.desc(),
-				qStore.createdAt.desc(),
-				qStore.updatedAt.desc())
+				getOrderSpecifier(sortOption))
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
 
@@ -71,6 +66,34 @@ public class StoreQueryRepository {
 		return new SliceImpl<>(storeList, pageable, hasNext);
 	}
 
+
+	private BooleanExpression cursorIdFiltering(UUID storeId) {
+		return storeId != null ? qStore.id.gt(storeId) : null;
+	}
+
+	private BooleanExpression categoryEquals(UUID category) {
+		return category != null ? qStore.storeCategory.any().category.id.eq(category) : null;
+	}
+
+	private BooleanExpression addressContains(String address) {
+		return address != null && !address.isEmpty() ? qStore.address.contains(address) : null;
+	}
+
+	private BooleanExpression roleBasedDeleteFilter(UserRole userRole) {
+		if (userRole == UserRole.MASTER) {
+			return null;
+		}
+		return qStore.deletedAt.isNull().and(qStore.deletedBy.isNull());
+	}
+
+	private OrderSpecifier<?> getOrderSpecifier(SortOption sortOption) {
+		return switch (sortOption) {
+			case CREATED_AT_DESC -> qStore.createdAt.desc();
+			case UPDATED_AT_ASC -> qStore.updatedAt.asc();
+			case UPDATED_AT_DESC -> qStore.updatedAt.desc();
+			default -> qStore.createdAt.asc();
+		};
+	}
 }
 
 

--- a/src/main/java/com/nbcamp/orderservice/domain/store/service/StoreService.java
+++ b/src/main/java/com/nbcamp/orderservice/domain/store/service/StoreService.java
@@ -60,7 +60,7 @@ public class StoreService {
 		return storeQueryRepository.findAllByStorePageable(
 			request.storeId(),
 			request.categoryId(),
-			request.address(),
+			extractAddress(request.address()),
 			request.sortOption(),
 			pageable,
 			user


### PR DESCRIPTION
### 매장 생성 기능
- 카테고리를 Category명이 아닌 UUID로 처리하여 중복 탐색 방지
- 서비스에서 확인하던 유저 롤 권한을 컨트롤러로 이동하여 초기 단계에서 검증
- 생성자를 활용해 불완전한 객체 생성 방지로 휴먼 에러 예방

### 매장 조회 기능
- 매장 조회 시 관리자와 일반 유저의 조회 조건을 분리하여 동적으로 변경
  - **관리자**: 삭제된 매장 포함 조회 가능
  - **일반 유저**: 삭제되지 않은 매장만 조회 가능
- 매장 전체 조회 시 입력이 많은 파라미터를 DTO로 통합 관리